### PR TITLE
feat: discovered hosts returned as dict

### DIFF
--- a/nectl/configs/cli.py
+++ b/nectl/configs/cli.py
@@ -60,7 +60,7 @@ def render_cmd(
             role=role,
             deployment_group=deployment_group,
         )
-        nectl.render_configs(hosts=hosts)
+        nectl.render_configs(hosts=hosts.values())
     except (DiscoveryError, RenderError) as e:
         print(f"Error: {e}")
         sys.exit(1)
@@ -103,7 +103,7 @@ def diff_cmd(
             deployment_group=deployment_group,
         )
         nectl.diff_configs(
-            hosts=hosts,
+            hosts=hosts.values(),
             username=username,
             password=password,
             ssh_private_key_file=ssh_key,
@@ -158,7 +158,7 @@ def apply_cmd(
         )
 
         print("Applying config to:")
-        print("\n".join([f"- {host.id}" for host in hosts]))
+        print("\n".join([f"- {host}" for host in hosts.keys()]))
 
         if not assumeyes:
             click.confirm(
@@ -167,7 +167,7 @@ def apply_cmd(
             )
 
         nectl.apply_configs(
-            hosts=hosts,
+            hosts=hosts.values(),
             username=username,
             password=password,
             ssh_private_key_file=ssh_key,
@@ -214,7 +214,7 @@ def get_cmd(
             deployment_group=deployment_group,
         )
         nectl.diff_configs(
-            hosts=hosts,
+            hosts=hosts.values(),
             username=username,
             password=password,
             ssh_private_key_file=ssh_key,

--- a/nectl/configs/cli.py
+++ b/nectl/configs/cli.py
@@ -213,7 +213,7 @@ def get_cmd(
             role=role,
             deployment_group=deployment_group,
         )
-        nectl.diff_configs(
+        nectl.get_configs(
             hosts=hosts.values(),
             username=username,
             password=password,

--- a/nectl/datatree/cli.py
+++ b/nectl/datatree/cli.py
@@ -74,11 +74,13 @@ def list_hosts_cmd(
         sys.exit(1)
 
     if output == "json":
-        print(json.dumps({h.id: h.dict() for h in hosts}, indent=4, default=str))
+        print(
+            json.dumps({h.id: h.dict() for h in hosts.values()}, indent=4, default=str)
+        )
     else:
         print(
             tabulate(
-                [h.dict() for h in hosts],
+                [h.dict() for h in hosts.values()],
                 headers="keys",
                 tablefmt="psql",
             )
@@ -118,7 +120,7 @@ def get_facts_cmd(
         print(f"Error: {e}")
         sys.exit(1)
 
-    host_facts = {host.id: host.facts for host in hosts}
+    host_facts = {host.id: host.facts for host in hosts.values()}
 
     if not check:
         print(facts_to_json_string(host_facts))

--- a/nectl/nectl.py
+++ b/nectl/nectl.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Nectl.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional, List
+from typing import Optional, List, Dict
 
 from .logging import get_logger
 from .settings import load_settings, Settings
@@ -38,7 +38,6 @@ class Nectl:
         """
         self.settings = settings if settings else load_settings(filepath=kit_filepath)
 
-    # TODO: return dict of hosts instead
     def get_hosts(
         self,
         hostname: Optional[str] = None,
@@ -46,7 +45,7 @@ class Nectl:
         site: Optional[str] = None,
         role: Optional[str] = None,
         deployment_group: Optional[str] = None,
-    ) -> List[Host]:
+    ) -> Dict[str, Host]:
         """
         Get hosts from datatree that match supplied filter parameters.
 
@@ -56,6 +55,9 @@ class Nectl:
             site (str): optional site to filter by.
             role (str): optional role to filter by.
             deployment_group (str): optional deployment_group to filter by.
+
+        Returns:
+            Dict[str, Host]: discovered host instances mapped by host ID.
 
         Raises:
             DiscoveryError: when an error has been encountered during data tree discovery.

--- a/tests/integration/test_hosts_discovery.py
+++ b/tests/integration/test_hosts_discovery.py
@@ -30,9 +30,12 @@ def test_should_return_8_hosts_when_getting_all_hosts(mock_settings):
     # WHEN fetching all hosts
     hosts = get_all_hosts(settings=settings)
 
-    # THEN expect each host to be of Host type
-    for host in hosts:
+    for host_id, host in hosts.items():
+        # THEN expect each host to be of Host type
         assert isinstance(host, Host), host
+
+        # THEN expect host ID key
+        assert host_id == host.id
 
     # THEN expect to have 8 hosts
     assert len(hosts) == 8
@@ -99,7 +102,7 @@ def test_should_return_no_customer_when_when_getting_all_hosts_and_no_customer_r
     settings.hosts_customer_regex = None
 
     # WHEN fetching all hosts
-    hosts = get_all_hosts(settings=settings)
+    hosts = list(get_all_hosts(settings=settings).values())
 
     # THEN expect site to be set
     assert hosts[0].site is not None
@@ -119,7 +122,7 @@ def test_should_return_no_customer_and_site_when_when_getting_all_hosts_and_no_c
     settings.hosts_site_regex = None
 
     # WHEN fetching all hosts
-    hosts = get_all_hosts(settings=settings)
+    hosts = list(get_all_hosts(settings=settings).values())
 
     # THEN expect customer to be none
     assert hosts[0].customer is None
@@ -128,7 +131,7 @@ def test_should_return_no_customer_and_site_when_when_getting_all_hosts_and_no_c
     assert hosts[0].customer is None
 
 
-def test_should_return_empty_list_when_getting_filtered_hosts_that_dont_exist(
+def test_should_return_empty_dict_when_getting_filtered_hosts_that_dont_exist(
     mock_settings,
 ):
     # GIVEN settings using mock kit
@@ -143,8 +146,8 @@ def test_should_return_empty_list_when_getting_filtered_hosts_that_dont_exist(
     # WHEN fetching hosts and using filters
     hosts = get_filtered_hosts(settings=settings, site=site, customer=customer)
 
-    # THEN expect result to be empty list
-    assert hosts == []
+    # THEN expect result to be empty dict
+    assert hosts == {}
 
 
 def test_should_return_2_hosts_when_getting_filtered_hosts_by_site_and_customer(
@@ -165,9 +168,12 @@ def test_should_return_2_hosts_when_getting_filtered_hosts_by_site_and_customer(
     # THEN expect to have 2 hosts
     assert len(hosts) == 2
 
-    for host in hosts:
+    for host_id, host in hosts.items():
         # THEN expect each result to be of Host type
         assert isinstance(host, Host), host
+
+        # THEN expect host ID key
+        assert host_id == host.id
 
         # THEN expect host customer
         assert host.customer == customer
@@ -194,9 +200,12 @@ def test_should_return_2_hosts_when_getting_filtered_hosts_by_site_and_role(
     # THEN expect to have 2 hosts
     assert len(hosts) == 2
 
-    for host in hosts:
+    for host_id, host in hosts.items():
         # THEN expect each result to be of Host type
         assert isinstance(host, Host), host
+
+        # THEN expect host ID key
+        assert host_id == host.id
 
         # THEN expect host role
         assert host.role == role
@@ -225,9 +234,12 @@ def test_should_return_2_hosts_when_getting_filtered_hosts_by_customer_and_deplo
     # THEN expect to have 2 hosts
     assert len(hosts) == 2
 
-    for host in hosts:
+    for host_id, host in hosts.items():
         # THEN expect each result to be of Host type
         assert isinstance(host, Host), host
+
+        # THEN expect host ID key
+        assert host_id == host.id
 
         # THEN expect host customer
         assert host.customer == customer
@@ -252,8 +264,10 @@ def test_should_return_host_properties_when_getting_filtered_hosts_by_site_and_c
     hostname = "core0"
 
     # WHEN fetching hosts and using filters
-    hosts = get_filtered_hosts(
-        settings=settings, site=site, customer=customer, hostname=hostname
+    hosts = list(
+        get_filtered_hosts(
+            settings=settings, site=site, customer=customer, hostname=hostname
+        ).values()
     )
 
     # THEN expect one host
@@ -299,7 +313,7 @@ def test_should_return_hosts_when_getting_all_hosts_that_are_not_directories(tmp
     )
 
     # WHEN fetching all hosts
-    hosts = get_all_hosts(settings=settings)
+    hosts = list(get_all_hosts(settings=settings).values())
 
     # THEN expect total hosts
     assert len(hosts) == 1


### PR DESCRIPTION
Update to the Nectl client interface to return a dict of hosts rather than a list which is more efficient for clients to work with.